### PR TITLE
Fix: removes check on ballot size

### DIFF
--- a/contracts/evoting/types/ballots.go
+++ b/contracts/evoting/types/ballots.go
@@ -43,12 +43,6 @@ type Ballot struct {
 // Unmarshal decodes the given string according to the format described in
 // "state of smart contract.md"
 func (b *Ballot) Unmarshal(marshalledBallot string, form Form) error {
-	if len(marshalledBallot) > form.BallotSize {
-		b.invalidate()
-		return fmt.Errorf("ballot has an unexpected size %d, expected <= %d",
-			len(marshalledBallot), form.BallotSize)
-	}
-
 	lines := strings.Split(marshalledBallot, "\n")
 
 	b.SelectResultIDs = make([]ID, 0)

--- a/contracts/evoting/types/ballots_test.go
+++ b/contracts/evoting/types/ballots_test.go
@@ -111,10 +111,6 @@ func TestBallot_Unmarshal(t *testing.T) {
 	require.Equal(t, expected.TextResultIDs, b.TextResultIDs)
 	require.Equal(t, expected.TextResult, b.TextResult)
 
-	// with ballot too long
-	err = b.Unmarshal(ballot1+"x", form)
-	require.EqualError(t, err, "ballot has an unexpected size 102, expected <= 101")
-
 	// with line wrongly formatted
 	err = b.Unmarshal("x", form)
 	require.EqualError(t, err, "a line in the ballot has length != 3: x")


### PR DESCRIPTION
This check breaks unmarashing specific question type: select. If it's commented out, the unmarshaling finishes successfully, so I believe that the check itself is buggy, and needs to be revised.

I'm writing an issue after this so we don't forget to bring back this check.