### PR TITLE
Cleanup frontend

### DIFF
--- a/scripts/local_vars.sh
+++ b/scripts/local_vars.sh
@@ -9,5 +9,8 @@ export SESSION_SECRET="session secret"
 export REACT_APP_NOMOCK=on
 # shellcheck disable=SC2155
 export DB_PATH="$(pwd)/nodes/llmdb"
+# The following two variables can be set to see log output from dela:
 #export PROXY_LOG=info
 #export LLVL=info
+# If this is set, you can login without Gaspar
+export REACT_APP_DEV_LOGIN="true"

--- a/scripts/local_vars.sh
+++ b/scripts/local_vars.sh
@@ -9,3 +9,5 @@ export SESSION_SECRET="session secret"
 export REACT_APP_NOMOCK=on
 # shellcheck disable=SC2155
 export DB_PATH="$(pwd)/nodes/llmdb"
+#export PROXY_LOG=info
+#export LLVL=info

--- a/web/backend/src/controllers/authentication.ts
+++ b/web/backend/src/controllers/authentication.ts
@@ -6,8 +6,8 @@ import { getUserPermissions, readSCIPER, setMapAuthorization } from '../authMana
 export const authenticationRouter = express.Router();
 
 authenticationRouter.get('/get_dev_login', (req, res) => {
-  if (process.env.NODE_ENV !== 'development') {
-    const err = `/get_dev_login can only be called in development: ${process.env.NODE_ENV}`;
+  if (process.env.REACT_APP_DEV_LOGIN !== 'true') {
+    const err = `/get_dev_login can only be called with DEV_LOGIN===true: ${process.env.DEV_LOGIN}`;
     console.error(err);
     res.status(500).send(err);
     return;

--- a/web/backend/src/controllers/proxies.ts
+++ b/web/backend/src/controllers/proxies.ts
@@ -33,13 +33,13 @@ proxiesRouter.put('/:nodeAddr', (req, res) => {
   const proxy = proxiesDB.get(nodeAddr);
 
   if (proxy === undefined) {
-    res.status(404).send('not found');
+    res.status(404).send(`proxy ${nodeAddr} not found`);
     return;
   }
   try {
     const bodydata = req.body;
     if (bodydata.Proxy === undefined) {
-      res.status(400).send('bad request, proxy is undefined');
+      res.status(400).send(`bad request, proxy ${nodeAddr} is undefined`);
       return;
     }
 
@@ -70,7 +70,7 @@ proxiesRouter.delete('/:nodeAddr', (req, res) => {
   const proxy = proxiesDB.get(nodeAddr);
 
   if (proxy === undefined) {
-    res.status(404).send('not found');
+    res.status(404).send(`proxy ${nodeAddr} not found`);
     return;
   }
 
@@ -98,7 +98,7 @@ proxiesRouter.get('/:nodeAddr', (req, res) => {
   const proxy = proxiesDB.get(decodeURIComponent(nodeAddr));
 
   if (proxy === undefined) {
-    res.status(404).send('not found');
+    res.status(404).send(`proxy ${nodeAddr} not found`);
     return;
   }
 

--- a/web/frontend/src/pages/form/components/DKGStatusRow.tsx
+++ b/web/frontend/src/pages/form/components/DKGStatusRow.tsx
@@ -200,6 +200,7 @@ const DKGStatusRow: FC<DKGStatusRowProps> = ({
   // already fetched)
   useEffect(() => {
     if (node !== null && proxy === null) {
+      var error;
       const fetchNodeProxy = async () => {
         try {
           setTimeout(() => {
@@ -209,29 +210,29 @@ const DKGStatusRow: FC<DKGStatusRowProps> = ({
           const response = await fetch(endpoints.getProxyAddress(node), request);
 
           if (!response.ok) {
-            const js = await response.json();
-            throw new Error(JSON.stringify(js));
+            error = Error(await response.text());
           } else {
             let dataReceived = await response.json();
             return dataReceived as NodeProxyAddress;
           }
         } catch (e) {
-          let errorMessage = t('errorRetrievingProxy');
-
           // Error triggered by timeout
           if (e instanceof DOMException) {
-            errorMessage += t('proxyUnreachable', { node: node });
+            error = t('proxyUnreachable', { node: node });
           } else {
-            errorMessage += t('error');
+            error = t('error');
           }
-
-          setInfo(errorMessage + e.message);
-          setStatus(NodeStatus.Unreachable);
-
-          // if we could not retrieve the proxy still resolve the promise
-          // so that promise.then() goes to onSuccess() but display the error
-          return { NodeAddr: node, Proxy: '' };
+          error += e;
         }
+        let errorMessage = t('errorRetrievingProxy');
+        errorMessage += error;
+
+        setInfo(errorMessage);
+        setStatus(NodeStatus.Unreachable);
+
+        // if we could not retrieve the proxy still resolve the promise
+        // so that promise.then() goes to onSuccess() but display the error
+        return { NodeAddr: node, Proxy: '' };
       };
 
       setDKGLoading(true);

--- a/web/frontend/src/pages/session/HandleLogin.tsx
+++ b/web/frontend/src/pages/session/HandleLogin.tsx
@@ -3,10 +3,11 @@ import { FlashLevel, FlashState } from 'index';
 
 // The backend will provide the client the URL to make a Tequila authentication.
 // We therefore redirect to this address.
+// If REACT_APP_DEV_LOGIN === "true", we allow an automatic login with SCIPER 100100.
 const handleLogin = async (fctx: FlashState) => {
   try {
     let res;
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.REACT_APP_DEV_LOGIN === 'true') {
       await fetch(ENDPOINT_DEV_LOGIN);
       window.location.reload();
       return;


### PR DESCRIPTION
Two commits to cleanup:
- one fixing a linter error with a throw in a catch block
- one changing the dev login to only be allowed if `REACT_APP_DEV_LOGIN === 'true'`