### PR TITLE
Add tests for the correct routes of the form management buttons

### DIFF
--- a/web/frontend/src/pages/form/components/AddVotersModal.tsx
+++ b/web/frontend/src/pages/form/components/AddVotersModal.tsx
@@ -169,6 +169,7 @@ export const AddVotersModal: FC<AddVotersModalProps> = ({
               </div>
               <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
                 <button
+                  data-testid="addVotersConfirm"
                   type="button"
                   className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
                   onClick={confirmChoice}>

--- a/web/frontend/src/pages/form/components/ChooseProxyModal.tsx
+++ b/web/frontend/src/pages/form/components/ChooseProxyModal.tsx
@@ -108,7 +108,9 @@ const ChooseProxyModal: FC<ChooseProxyModalProps> = ({
                   <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 sm:mx-0 sm:h-10 sm:w-10">
                     <CogIcon className="h-6 w-6 text-indigo-600" aria-hidden="true" />
                   </div>
-                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                  <div
+                    data-testid="nodeSetup"
+                    className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                     <Dialog.Title as="h3" className="text-lg leading-6 font-medium text-gray-900">
                       {t('nodeSetup')}
                     </Dialog.Title>

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -358,9 +358,12 @@ test('Assert "Vote" button is visible to admin/non-admin voter user', async ({ p
 
 test('Assert "Vote" button gets voting form', async ({ page }) => {
     await setUpMocks(page, 1, 6)
-    for (const user of [SCIPER_USER, SCIPER_ADMIN]) {
-      await logIn(page, user);
+      await logIn(page, SCIPER_USER);
       page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`)
       await page.getByRole('button', { name: i18n.t('vote') }).click();
-    }
+      // go back to form management page
+      await setUp(page, `/forms/${FORMID}`);
+      await logIn(page, SCIPER_ADMIN);
+      page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`)
+      await page.getByRole('button', { name: i18n.t('vote') }).click();
 });

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -103,14 +103,11 @@ async function assertIsOnlyVisibleInStates(
     });
   }
   for (const i of [0, 1, 2, 3, 4, 5].filter((x) => !states.includes(x))) {
-    await test.step(
-      `Assert is not visible in form state '${prettyFormStates.at(i)}'`,
-      async () => {
-        await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
-        await page.reload({ waitUntil: 'networkidle' });
-        await expect(locator).toBeHidden();
-      }
-    );
+    await test.step(`Assert is not visible in form state '${prettyFormStates.at(i)}'`, async () => {
+      await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
+      await page.reload({ waitUntil: 'networkidle' });
+      await expect(locator).toBeHidden();
+    });
   }
 }
 

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -12,6 +12,15 @@ import { FORMID, mockDKGActors, mockFormsFormID } from './mocks/evoting';
 
 initI18n();
 
+const prettyFormStates = new Map([
+  [0, 'Initial'],
+  [1, 'Open'],
+  [2, 'Closed'],
+  [3, 'ShuffledBallots'],
+  [4, 'PubSharesSubmitted'],
+  [5, 'ResultAvailable'],
+]);
+
 // main elements
 
 async function setUpMocks(
@@ -71,18 +80,21 @@ async function assertIsOnlyVisibleInStates(
   initialized?: boolean
 ) {
   for (const i of states) {
-    await test.step(`Assert is visible in state ${i}`, async () => {
+    await test.step(`Assert is visible in form state '${prettyFormStates.get(i)}'`, async () => {
       await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
       await page.reload({ waitUntil: 'networkidle' });
       await assert(page, locator);
     });
   }
   for (const i of [0, 1, 2, 3, 4, 5].filter((x) => !states.includes(x))) {
-    await test.step(`Assert is not visible in state ${i}`, async () => {
-      await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
-      await page.reload({ waitUntil: 'networkidle' });
-      await expect(locator).toBeHidden();
-    });
+    await test.step(
+      `Assert is not visible in form state '${prettyFormStates.get(i)}'`,
+      async () => {
+        await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
+        await page.reload({ waitUntil: 'networkidle' });
+        await expect(locator).toBeHidden();
+      }
+    );
   }
 }
 

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -155,6 +155,28 @@ test('Assert "Setup" button is only visible to owner', async ({ page }) => {
   );
 });
 
+test('Assert "Setup" button calls route to setup node', async ({ page, baseURL }) => {
+  await setUpMocks(page, 0, 0, true);
+  await logIn(page, SCIPER_OTHER_ADMIN);
+  // we expect one call with the chosen worker node
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/evoting/services/dkg/actors/${FORMID}` &&
+      request.method() === 'PUT' &&
+      body.Action === 'setup' &&
+      body.Proxy === Worker1.Proxy
+    );
+  });
+  // open node selection window
+  await page.getByRole('button', { name: i18n.t('setup') }).click();
+  await expect(page.getByTestId('nodeSetup')).toBeVisible();
+  // choose second worker node
+  await page.getByLabel(Worker1.NodeAddr).check();
+  // confirm
+  await page.getByRole('button', { name: i18n.t('setupNode') }).click();
+});
+
 test('Assert "Open" button is only visible to owner', async ({ page }) => {
   await assertIsOnlyVisibleInStates(
     page,

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -209,6 +209,20 @@ test('Assert "Cancel" button is only visible to owner', async ({ page }) => {
   );
 });
 
+test('Assert "Cancel" button calls route to cancel form', async ({ page, baseURL }) => {
+  await setUpMocks(page, 1, 6);
+  await logIn(page, SCIPER_OTHER_ADMIN);
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/evoting/forms/${FORMID}` &&
+      request.method() === 'PUT' &&
+      body.Action === 'cancel'
+    );
+  });
+  await page.getByRole('button', { name: i18n.t('cancel') }).click();
+});
+
 test('Assert "Close" button is only visible to owner', async ({ page }) => {
   await assertIsOnlyVisibleInStates(
     page,

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -186,6 +186,20 @@ test('Assert "Open" button is only visible to owner', async ({ page }) => {
   );
 });
 
+test('Assert "Open" button calls route to open form', async ({ page, baseURL }) => {
+  await setUpMocks(page, 0, 6);
+  await logIn(page, SCIPER_OTHER_ADMIN);
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/evoting/forms/${FORMID}` &&
+      request.method() === 'PUT' &&
+      body.Action === 'open'
+    );
+  });
+  await page.getByRole('button', { name: i18n.t('open') }).click();
+});
+
 test('Assert "Cancel" button is only visible to owner', async ({ page }) => {
   await assertIsOnlyVisibleInStates(
     page,

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -7,11 +7,15 @@ import {
   SCIPER_OTHER_USER,
   SCIPER_USER,
   mockDKGActors as mockAPIDKGActors,
+  mockAddRole,
+  mockDKGActorsFormID,
+  mockForms,
   mockPersonalInfo,
   mockProxies,
-  mockAddRole,
+  mockServicesShuffle,
 } from './mocks/api';
-import { FORMID, mockDKGActors, mockFormsFormID } from './mocks/evoting';
+import { mockDKGActors, mockFormsFormID } from './mocks/evoting';
+import { FORMID } from './mocks/shared';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
 import Worker1 from './json/api/proxies/dela-worker-1.json';
 import Worker2 from './json/api/proxies/dela-worker-2.json';
@@ -46,6 +50,9 @@ async function setUpMocks(
   await mockDKGActors(page, dkgActorsStatus, initialized);
   await mockAPIDKGActors(page);
   await mockPersonalInfo(page);
+  await mockDKGActorsFormID(page);
+  await mockServicesShuffle(page);
+  await mockForms(page);
 }
 
 test.beforeEach(async ({ page }) => {
@@ -107,16 +114,26 @@ async function assertIsOnlyVisibleInStates(
   }
 }
 
-async function assertRouteIsCalled(page: page, url: string, key: string, action: string, formStatus: number, confirmation: boolean, dkgActorsStatus?: number, initialized?: boolean) {
-  await setUpMocks(page, formStatus, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
+async function assertRouteIsCalled(
+  page: page,
+  url: string,
+  key: string,
+  action: string,
+  formStatus: number,
+  confirmation: boolean,
+  dkgActorsStatus?: number,
+  initialized?: boolean
+) {
+  await setUpMocks(
+    page,
+    formStatus,
+    dkgActorsStatus === undefined ? 6 : dkgActorsStatus,
+    initialized
+  );
   await logIn(page, SCIPER_OTHER_ADMIN);
   page.waitForRequest(async (request) => {
     const body = await request.postDataJSON();
-    return (
-      request.url() === url &&
-      request.method() === 'PUT' &&
-      body.Action === action
-    );
+    return request.url() === url && request.method() === 'PUT' && body.Action === action;
   });
   await page.getByRole('button', { name: i18n.t(key) }).click();
   if (confirmation) {
@@ -232,7 +249,15 @@ test('Assert "Open" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Open" button calls route to open form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/forms/${FORMID}`, 'open', 'open', 0, false, 6);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/forms/${FORMID}`,
+    'open',
+    'open',
+    0,
+    false,
+    6
+  );
 });
 
 test('Assert "Cancel" button is only visible to owner', async ({ page }) => {
@@ -245,7 +270,14 @@ test('Assert "Cancel" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Cancel" button calls route to cancel form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/forms/${FORMID}`, 'cancel', 'cancel', 1, true);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/forms/${FORMID}`,
+    'cancel',
+    'cancel',
+    1,
+    true
+  );
 });
 
 test('Assert "Close" button is only visible to owner', async ({ page }) => {
@@ -258,7 +290,14 @@ test('Assert "Close" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Close" button calls route to close form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/forms/${FORMID}`, 'close', 'close', 1, true);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/forms/${FORMID}`,
+    'close',
+    'close',
+    1,
+    true
+  );
 });
 
 test('Assert "Shuffle" button is only visible to owner', async ({ page }) => {
@@ -271,7 +310,14 @@ test('Assert "Shuffle" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Shuffle" button calls route to shuffle form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/services/shuffle/${FORMID}`, 'shuffle', 'shuffle', 2, false);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/services/shuffle/${FORMID}`,
+    'shuffle',
+    'shuffle',
+    2,
+    false
+  );
 });
 
 test('Assert "Decrypt" button is only visible to owner', async ({ page }) => {
@@ -284,7 +330,14 @@ test('Assert "Decrypt" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Decrypt" button calls route to decrypt form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/services/dkg/actors/${FORMID}`, 'decrypt', 'computePubshares', 3, false);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/services/dkg/actors/${FORMID}`,
+    'decrypt',
+    'computePubshares',
+    3,
+    false
+  );
 });
 
 test('Assert "Combine" button is only visible to owner', async ({ page }) => {
@@ -297,7 +350,14 @@ test('Assert "Combine" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Combine" button calls route to combine form', async ({ page, baseURL }) => {
-  await assertRouteIsCalled(page, `${baseURL}/api/evoting/forms/${FORMID}`, 'combine', 'combineShares', 4, false);
+  await assertRouteIsCalled(
+    page,
+    `${baseURL}/api/evoting/forms/${FORMID}`,
+    'combine',
+    'combineShares',
+    4,
+    false
+  );
 });
 
 test('Assert "Delete" button is only visible to owner', async ({ page }) => {
@@ -312,13 +372,12 @@ test('Assert "Delete" button is only visible to owner', async ({ page }) => {
 
 test('Assert "Delete" button calls route to delete form', async ({ page, baseURL }) => {
   for (const i of [0, 1, 2, 3, 4, 6]) {
-    await setUpMocks(page, i, 6)
+    await setUpMocks(page, i, 6);
     await logIn(page, SCIPER_OTHER_ADMIN);
     page.waitForRequest(async (request) => {
       const body = await request.postDataJSON();
       return (
-        request.url() === `${baseURL}/api/evoting/forms/${FORMID}` &&
-        request.method() === 'DELETE'
+        request.url() === `${baseURL}/api/evoting/forms/${FORMID}` && request.method() === 'DELETE'
       );
     });
     await page.getByRole('button', { name: i18n.t('delete') }).click();
@@ -357,13 +416,13 @@ test('Assert "Vote" button is visible to admin/non-admin voter user', async ({ p
 });
 
 test('Assert "Vote" button gets voting form', async ({ page }) => {
-    await setUpMocks(page, 1, 6)
-      await logIn(page, SCIPER_USER);
-      page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`)
-      await page.getByRole('button', { name: i18n.t('vote') }).click();
-      // go back to form management page
-      await setUp(page, `/forms/${FORMID}`);
-      await logIn(page, SCIPER_ADMIN);
-      page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`)
-      await page.getByRole('button', { name: i18n.t('vote') }).click();
+  await setUpMocks(page, 1, 6);
+  await logIn(page, SCIPER_USER);
+  page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`);
+  await page.getByRole('button', { name: i18n.t('vote') }).click();
+  // go back to form management page
+  await setUp(page, `/forms/${FORMID}`);
+  await logIn(page, SCIPER_ADMIN);
+  page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`);
+  await page.getByRole('button', { name: i18n.t('vote') }).click();
 });

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -19,6 +19,7 @@ const prettyFormStates = new Map([
   [3, 'ShuffledBallots'],
   [4, 'PubSharesSubmitted'],
   [5, 'ResultAvailable'],
+  [6, 'Canceled'],
 ]);
 
 // main elements
@@ -184,10 +185,11 @@ test('Assert "Combine" button is only visible to owner', async ({ page }) => {
 });
 
 test('Assert "Delete" button is only visible to owner', async ({ page }) => {
+  test.setTimeout(60000);  // Firefox is exceeding the default timeout on this test
   await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('delete') }),
-    [0, 1, 2, 3, 4],
+    [0, 1, 2, 3, 4, 6],
     assertIsOnlyVisibleToOwner
   );
 });

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -23,15 +23,15 @@ import Worker3 from './json/api/proxies/dela-worker-3.json';
 
 initI18n();
 
-const prettyFormStates = new Map([
-  [0, 'Initial'],
-  [1, 'Open'],
-  [2, 'Closed'],
-  [3, 'ShuffledBallots'],
-  [4, 'PubSharesSubmitted'],
-  [5, 'ResultAvailable'],
-  [6, 'Canceled'],
-]);
+const prettyFormStates = [
+  'Initial',
+  'Open',
+  'Closed',
+  'ShuffledBallots',
+  'PubSharesSubmitted',
+  'ResultAvailable',
+  'Canceled',
+];
 
 // main elements
 
@@ -96,7 +96,7 @@ async function assertIsOnlyVisibleInStates(
   initialized?: boolean
 ) {
   for (const i of states) {
-    await test.step(`Assert is visible in form state '${prettyFormStates.get(i)}'`, async () => {
+    await test.step(`Assert is visible in form state '${prettyFormStates.at(i)}'`, async () => {
       await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
       await page.reload({ waitUntil: 'networkidle' });
       await assert(page, locator);
@@ -104,7 +104,7 @@ async function assertIsOnlyVisibleInStates(
   }
   for (const i of [0, 1, 2, 3, 4, 5].filter((x) => !states.includes(x))) {
     await test.step(
-      `Assert is not visible in form state '${prettyFormStates.get(i)}'`,
+      `Assert is not visible in form state '${prettyFormStates.at(i)}'`,
       async () => {
         await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
         await page.reload({ waitUntil: 'networkidle' });

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -375,7 +375,6 @@ test('Assert "Delete" button calls route to delete form', async ({ page, baseURL
     await setUpMocks(page, i, 6);
     await logIn(page, SCIPER_OTHER_ADMIN);
     page.waitForRequest(async (request) => {
-      const body = await request.postDataJSON();
       return (
         request.url() === `${baseURL}/api/evoting/forms/${FORMID}` && request.method() === 'DELETE'
       );

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -62,96 +62,120 @@ async function assertIsOnlyVisibleToOwner(page: page, locator: locator) {
   });
 }
 
-async function assertIsOnlyVisibleToOwnerStates(
+async function assertIsOnlyVisibleInStates(
   page: page,
   locator: locator,
   states: Array,
+  assert: Function,
   dkgActorsStatus?: number,
   initialized?: boolean
 ) {
   for (const i of states) {
-    await test.step(`Assert is only visible to owner in state ${i}`, async () => {
+    await test.step(`Assert is visible in state ${i}`, async () => {
       await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
       await page.reload({ waitUntil: 'networkidle' });
-      await assertIsOnlyVisibleToOwner(page, locator);
+      await assert(page, locator);
+    });
+  }
+  for (const i of [0, 1, 2, 3, 4, 5].filter((x) => !states.includes(x))) {
+    await test.step(`Assert is not visible in state ${i}`, async () => {
+      await setUpMocks(page, i, dkgActorsStatus === undefined ? 6 : dkgActorsStatus, initialized);
+      await page.reload({ waitUntil: 'networkidle' });
+      await expect(locator).toBeHidden();
     });
   }
 }
 
 test('Assert "Add voters" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(page, page.getByTestId('addVotersButton'), [0, 1]);
+  await assertIsOnlyVisibleInStates(
+    page,
+    page.getByTestId('addVotersButton'),
+    [0, 1],
+    assertIsOnlyVisibleToOwner
+  );
 });
 
 test('Assert "Initialize" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('initialize') }),
     [0],
+    assertIsOnlyVisibleToOwner,
     0,
     false
   );
 });
 
 test('Assert "Setup" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('setup') }),
     [0],
+    assertIsOnlyVisibleToOwner,
     0,
     true
   );
 });
 
 test('Assert "Open" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(page, page.getByRole('button', { name: i18n.t('open') }), [
-    0,
-  ]);
+  await assertIsOnlyVisibleInStates(
+    page,
+    page.getByRole('button', { name: i18n.t('open') }),
+    [0],
+    assertIsOnlyVisibleToOwner
+  );
 });
 
 test('Assert "Cancel" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('cancel') }),
-    [1]
+    [1],
+    assertIsOnlyVisibleToOwner
   );
 });
 
 test('Assert "Close" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('close') }),
-    [1]
+    [1],
+    assertIsOnlyVisibleToOwner
   );
 });
 
 test('Assert "Shuffle" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('shuffle') }),
-    [2]
+    [2],
+    assertIsOnlyVisibleToOwner
   );
 });
 
 test('Assert "Decrypt" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('decrypt') }),
-    [3]
+    [3],
+    assertIsOnlyVisibleToOwner
   );
 });
 
 test('Assert "Combine" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('combine') }),
-    [4]
+    [4],
+    assertIsOnlyVisibleToOwner
   );
 });
 
 test('Assert "Delete" button is only visible to owner', async ({ page }) => {
-  await assertIsOnlyVisibleToOwnerStates(
+  await assertIsOnlyVisibleInStates(
     page,
     page.getByRole('button', { name: i18n.t('delete') }),
-    [0, 1, 2, 3, 4]
+    [0, 1, 2, 3, 4],
+    assertIsOnlyVisibleToOwner
   );
 });

--- a/web/frontend/tests/json/api/personal_info/654321.json
+++ b/web/frontend/tests/json/api/personal_info/654321.json
@@ -1,0 +1,7 @@
+{
+  "sciper": 654321,
+  "lastName": "654321",
+  "firstName": "sciper-#",
+  "isLoggedIn": true,
+  "authorization": {}
+}

--- a/web/frontend/tests/json/evoting/dkgActors/uninitialized.json
+++ b/web/frontend/tests/json/evoting/dkgActors/uninitialized.json
@@ -5,6 +5,6 @@
   "Args": {
     "error": "actor not found",
     "method": "GET",
-    "url": "/evoting/services/dkg/actors/d3319c58a3bea17dafe61168610757b9a7bb0d922c1f2aa30b8ad537646b1c07"
+    "url": "/evoting/services/dkg/actors/b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4"
   }
 }

--- a/web/frontend/tests/json/evoting/forms/canceled.json
+++ b/web/frontend/tests/json/evoting/forms/canceled.json
@@ -1,0 +1,64 @@
+{
+  "FormID": "b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4",
+  "Configuration": {
+    "Title": {
+      "En": "Colours",
+      "Fr": "",
+      "De": ""
+    },
+    "Scaffold": [
+      {
+        "ID": "yOakwFnR",
+        "Title": {
+          "En": "Colours",
+          "Fr": "Couleurs",
+          "De": "Farben"
+        },
+        "Order": [
+          "CLgNiLbC"
+        ],
+        "Subjects": [],
+        "Selects": [
+          {
+            "ID": "CLgNiLbC",
+            "Title": {
+              "En": "RGB",
+              "Fr": "RGB",
+              "De": "RGB"
+            },
+            "MaxN": 2,
+            "MinN": 1,
+            "Choices": [
+              "{\"en\":\"Red\",\"fr\":\"Rouge\",\"de\":\"Rot\"}",
+              "{\"en\":\"Green\",\"fr\":\"Vert\",\"de\":\"Grün\"}",
+              "{\"en\":\"Blue\",\"fr\":\"Bleu\",\"de\":\"Blau\"}"
+            ],
+            "Hint": {
+              "En": "",
+              "Fr": "",
+              "De": ""
+            }
+          }
+        ],
+        "Ranks": [],
+        "Texts": []
+      }
+    ]
+  },
+  "Status": 2,
+  "Pubkey": "612fdc867be1a5faccf16e5aed946880005840ee04aaa382fe181a2b46dc9a24",
+  "Result": [],
+  "Roster": [
+    "grpc://dela-worker-0:2000",
+    "grpc://dela-worker-1:2000",
+    "grpc://dela-worker-2:2000",
+    "grpc://dela-worker-3:2000"
+  ],
+  "ChunksPerBallot": 1,
+  "BallotSize": 23,
+  "Voters": [
+    "oUItDdhhEE",
+    "WZyqP1gssL",
+    "K7ZNvumBVc"
+  ]
+}

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -1,6 +1,7 @@
 export const SCIPER_ADMIN = '123456';
 export const SCIPER_OTHER_ADMIN = '987654';
 export const SCIPER_USER = '789012';
+export const SCIPER_OTHER_USER = '654321';
 
 export async function mockProxy(page: page) {
   await page.route('/api/config/proxy', async (route) => {

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -3,6 +3,14 @@ export const SCIPER_OTHER_ADMIN = '987654';
 export const SCIPER_USER = '789012';
 export const SCIPER_OTHER_USER = '654321';
 
+export async function mockDKGActors(page: page) {
+  await page.route('/api/evoting/services/dkg/actors', async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status: 200 });
+    }
+  });
+}
+
 export async function mockProxy(page: page) {
   await page.route('/api/config/proxy', async (route) => {
     await route.fulfill({

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -81,3 +81,9 @@ export async function mockLogout(page: page) {
     await route.fulfill({});
   });
 }
+
+export async function mockAddRole(page: page) {
+  await page.route('/api/add_role', async (route) => {
+    await route.fulfill({ status: 200 });
+  });
+}

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -1,7 +1,10 @@
+import { FORMID } from './shared';
 export const SCIPER_ADMIN = '123456';
 export const SCIPER_OTHER_ADMIN = '987654';
 export const SCIPER_USER = '789012';
 export const SCIPER_OTHER_USER = '654321';
+
+// /api/evoting
 
 export async function mockDKGActors(page: page) {
   await page.route('/api/evoting/services/dkg/actors', async (route) => {
@@ -10,6 +13,32 @@ export async function mockDKGActors(page: page) {
     }
   });
 }
+
+export async function mockDKGActorsFormID(page: page) {
+  await page.route(`/api/evoting/services/dkg/actors/${FORMID}`, async (route) => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({ status: 200 });
+    }
+  });
+}
+
+export async function mockServicesShuffle(page: page) {
+  await page.route('/api/evoting/services/shuffle/', async (route) => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({ status: 200 });
+    }
+  });
+}
+
+export async function mockForms(page: page) {
+  await page.route(`/api/evoting/forms/${FORMID}`, async (route) => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({ status: 200 });
+    }
+  });
+}
+
+// /api/config
 
 export async function mockProxy(page: page) {
   await page.route('/api/config/proxy', async (route) => {
@@ -24,6 +53,8 @@ export async function mockProxy(page: page) {
     });
   });
 }
+
+// /api
 
 export async function mockProxies(page: page, workerNumber: number) {
   await page.route(

--- a/web/frontend/tests/mocks/evoting.ts
+++ b/web/frontend/tests/mocks/evoting.ts
@@ -2,8 +2,7 @@ import Worker0 from './../json/api/proxies/dela-worker-0.json';
 import Worker1 from './../json/api/proxies/dela-worker-1.json';
 import Worker2 from './../json/api/proxies/dela-worker-2.json';
 import Worker3 from './../json/api/proxies/dela-worker-3.json';
-
-export const FORMID = 'b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4';
+import { FORMID } from './shared';
 
 export async function mockForms(page: page, empty: boolean = true) {
   // clear current mock

--- a/web/frontend/tests/mocks/evoting.ts
+++ b/web/frontend/tests/mocks/evoting.ts
@@ -42,6 +42,7 @@ export async function mockFormsFormID(page: page, formStatus: number) {
       'shuffled.json',
       'decrypted.json',
       'combined.json',
+      'canceled.json',
     ][formStatus];
     await route.fulfill({
       path: `./tests/json/evoting/forms/${formFile}`,

--- a/web/frontend/tests/mocks/shared.ts
+++ b/web/frontend/tests/mocks/shared.ts
@@ -1,0 +1,1 @@
+export const FORMID = 'b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4';

--- a/web/frontend/tests/shared.ts
+++ b/web/frontend/tests/shared.ts
@@ -12,6 +12,8 @@ import {
   mockProxy,
 } from './mocks/api';
 
+export const FORMID = 'b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4';
+
 export function initI18n() {
   i18n.init({
     resources: { en, fr, de },


### PR DESCRIPTION
This PR adds

* tests that verify that form management buttons are only visible in certain states
* tests that test that the correct routes are called when clicking on the form creation buttons.

It closes #72 .
