### PR TITLE
Running crash tests up to three times

### DIFF
--- a/.github/workflows/go_integration_tests.yml
+++ b/.github/workflows/go_integration_tests.yml
@@ -48,7 +48,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run the crash test
-        run: go test -timeout 10m -run TestCrash ./integration/...
+        run: |
+          for a in $( seq 3 ); do
+            echo "Testing sequence $a"
+            go test -timeout 10m -run TestCrash ./integration/... && exit 0
+          done
+          exit 1
   revote:
     name: Test revote
     runs-on: ubuntu-latest


### PR DESCRIPTION
The crash tests often fail, but sometimes also run successfully. This PR runs them 3 times and returns OK if they are run OK at least once.

Caught it to work OK the first time I ran it:

https://github.com/c4dt/d-voting/actions/runs/7915156731/job/21606392047?pr=119#step:4:75

Thank you for opening a pull request with this project, please also:

* [x] add a brief description of your changes here
* [x] assign the PR to yourself, or to the person(s) working on it
* [x] start in `draft` mode and `in progress` pipeline in the project (if applicable)
* [x] if applicable, add this PR to its related issue by one of the special keywords [Closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
* once it's ready 
  * [x] put it in the `Review` or `Ready4Merge` pipeline in the project (if applicable) 
  * [x] remove `draft`
  * [x] assign a reviewer
