### PR TITLE
feat: hide elections on blocklist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,5 @@ PUBLIC_KEY=3e5fcaed4c5d79a8eccceeb087ee0a13b8f91d917ed62017a9cd28e13b228389
 REACT_APP_DEV_LOGIN=true                                # debugging admin login /!\ disable in production /!\
 REACT_APP_RANDOMIZE_VOTE_ID=true                        # randomize voter ID for debugging /!\ disable in production /!\
 REACT_APP_SCIPER_ADMIN=123456                           # debugging admin ID /!\ disable in production /!\
+REACT_APP_BLOCKLIST=                                    # comma-separad form IDs to hide from non-admin users
 SESSION_SECRET=kaibaaF9                                 # choose any secret

--- a/web/frontend/src/pages/form/components/FormRow.tsx
+++ b/web/frontend/src/pages/form/components/FormRow.tsx
@@ -14,6 +14,9 @@ const SUBJECT_ELECTION = 'election';
 const ACTION_CREATE = 'create';
 
 const FormRow: FC<FormRowProps> = ({ form }) => {
+  const Blocklist = process.env.REACT_APP_BLOCKLIST
+    ? process.env.REACT_APP_BLOCKLIST.split(',')
+    : [];
   const [titles, setTitles] = useState<any>({});
   const authCtx = useContext(AuthContext);
   useEffect(() => {
@@ -31,11 +34,21 @@ const FormRow: FC<FormRowProps> = ({ form }) => {
     }
   });
   const formTitle = formRowI18n.t('title', { ns: 'form', fallbackLng: 'en' });
+  const isAdmin = authCtx.isLogged && authCtx.isAllowed(SUBJECT_ELECTION, ACTION_CREATE);
+  const isBlocked = Blocklist.includes(form.FormID);
+  if (!isAdmin && isBlocked) return null;
+  const styleText = isBlocked
+    ? 'text-gray-700 hover:text-gray-700'
+    : 'text-gray-700 hover:text-[#ff0000]';
+  const styleBox = isBlocked
+    ? 'bg-gray-200 border-b hover: bg-gray-200'
+    : 'bg-white border-b hover:bg-gray-50 ';
+
   return (
-    <tr className="bg-white border-b hover:bg-gray-50 ">
+    <tr className={styleBox}>
       <td className="px-1.5 sm:px-6 py-4 font-medium text-gray-900 whitespace-nowrap truncate">
-        {authCtx.isLogged && authCtx.isAllowed(SUBJECT_ELECTION, ACTION_CREATE) ? (
-          <Link className="text-gray-700 hover:text-[#ff0000]" to={`/forms/${form.FormID}`}>
+        {isAdmin ? (
+          <Link className={styleText} to={`/forms/${form.FormID}`}>
             <div className="max-w-[20vw] truncate">{formTitle}</div>
           </Link>
         ) : (

--- a/web/frontend/src/pages/form/components/FormRow.tsx
+++ b/web/frontend/src/pages/form/components/FormRow.tsx
@@ -14,9 +14,7 @@ const SUBJECT_ELECTION = 'election';
 const ACTION_CREATE = 'create';
 
 const FormRow: FC<FormRowProps> = ({ form }) => {
-  const Blocklist = process.env.REACT_APP_BLOCKLIST
-    ? process.env.REACT_APP_BLOCKLIST.split(',')
-    : [];
+  const Blocklist = process.env.REACT_APP_BLOCKLIST?.split(',') ?? [];
   const [titles, setTitles] = useState<any>({});
   const authCtx = useContext(AuthContext);
   useEffect(() => {
@@ -41,8 +39,8 @@ const FormRow: FC<FormRowProps> = ({ form }) => {
     ? 'text-gray-700 hover:text-gray-700'
     : 'text-gray-700 hover:text-[#ff0000]';
   const styleBox = isBlocked
-    ? 'bg-gray-200 border-b hover: bg-gray-200'
-    : 'bg-white border-b hover:bg-gray-50 ';
+    ? 'bg-gray-200 border-b hover:bg-gray-200'
+    : 'bg-white border-b hover:bg-gray-50';
 
   return (
     <tr className={styleBox}>


### PR DESCRIPTION
This pull requests allows the administrator to provide a comma-separated list of elections to hide from non-admin users in the GUI.

Tested:

* [x] with empty list
* [x] one element
* [x] two elements  
