### PR TITLE
Fix Playwright tests that did not include several last minute changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ REACT_APP_RANDOMIZE_VOTE_ID=true                        # randomize voter ID for
 REACT_APP_SCIPER_ADMIN=123456                           # debugging admin ID /!\ disable in production /!\
 REACT_APP_BLOCKLIST=                                    # comma-separad form IDs to hide from non-admin users
 SESSION_SECRET=kaibaaF9                                 # choose any secret
+REACT_APP_VERSION="unknown"
+REACT_APP_BUILD="unknown"
+REACT_APP_BUILD_TIME="after_2024_03"

--- a/web/frontend/tests/ballot.spec.ts
+++ b/web/frontend/tests/ballot.spec.ts
@@ -71,7 +71,7 @@ test('Assert ballot is displayed properly', async ({ page }) => {
     await expect(
       page.getByText(i18n.t('selectBetween', { minSelect: select.MinN, maxSelect: select.MaxN }))
     ).toBeVisible();
-    for (const choice of select.Choices.map((x) => JSON.parse(x))) {
+    for (const choice of select.Choices.map((x) => JSON.parse(x.Choice))) {
       await expect(page.getByRole('checkbox', { name: choice.en })).toBeVisible();
     }
   }
@@ -100,7 +100,7 @@ test('Assert minimum/maximum number of choices are handled correctly', async ({ 
     await test.step(
       `Assert maximum number of choices (${select.MaxN}) are handled correctly`,
       async () => {
-        for (const choice of select.Choices.map((x) => JSON.parse(x))) {
+        for (const choice of select.Choices.map((x) => JSON.parse(x.Choice))) {
           await page.getByRole('checkbox', { name: choice.en }).setChecked(true);
         }
         await castVoteButton.click();
@@ -134,12 +134,12 @@ test('Assert that correct number of choices are accepted', async ({ page, baseUR
   });
   await page
     .getByRole('checkbox', {
-      name: JSON.parse(Form.Configuration.Scaffold.at(0).Selects.at(0).Choices.at(0)).en,
+      name: JSON.parse(Form.Configuration.Scaffold.at(0).Selects.at(0).Choices.at(0).Choice).en,
     })
     .setChecked(true);
   await page
     .getByRole('checkbox', {
-      name: JSON.parse(Form.Configuration.Scaffold.at(1).Selects.at(0).Choices.at(0)).en,
+      name: JSON.parse(Form.Configuration.Scaffold.at(1).Selects.at(0).Choices.at(0).Choice).en,
     })
     .setChecked(true);
   await page.getByRole('button', { name: i18n.t('castVote') }).click();

--- a/web/frontend/tests/formIndex.spec.ts
+++ b/web/frontend/tests/formIndex.spec.ts
@@ -146,10 +146,6 @@ test('Assert all forms are displayed correctly for unauthenticated user', async 
     let name = translate(form.Title);
     let row = await table.getByRole('row', { name: name });
     await expect(row).toBeVisible();
-    // row entry leads to form view
-    let link = await row.getByRole('link', { name: name });
-    await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute('href', `/forms/${form.FormID}`);
     await assertQuickAction(row, form);
   }
   await goForward(page);

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -4,7 +4,6 @@ import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp } from './shar
 import {
   SCIPER_ADMIN,
   SCIPER_OTHER_ADMIN,
-  SCIPER_OTHER_USER,
   SCIPER_USER,
   mockDKGActors as mockAPIDKGActors,
   mockAddRole,
@@ -151,11 +150,7 @@ test('Assert "Add voters" button allows to add voters', async ({ page, baseURL }
       request.method() === 'POST' &&
       body.permission === 'vote' &&
       body.subject === FORMID &&
-      body.userIds.toString() === [
-        SCIPER_OTHER_ADMIN,
-        SCIPER_ADMIN,
-        SCIPER_USER,
-      ].join(',')
+      body.userIds.toString() === [SCIPER_OTHER_ADMIN, SCIPER_ADMIN, SCIPER_USER].join(',')
     );
   });
   await page.getByTestId('addVotersButton').click();

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -144,19 +144,20 @@ test('Assert "Add voters" button allows to add voters', async ({ page, baseURL }
   await setUpMocks(page, 0, 6);
   await mockAddRole(page);
   await logIn(page, SCIPER_OTHER_ADMIN);
-  // we expect one call per new voter
-  for (const sciper of [SCIPER_OTHER_ADMIN, SCIPER_ADMIN, SCIPER_USER]) {
-    page.waitForRequest(async (request) => {
-      const body = await request.postDataJSON();
-      return (
-        request.url() === `${baseURL}/api/add_role` &&
-        request.method() === 'POST' &&
-        body.permission === 'vote' &&
-        body.subject === FORMID &&
-        body.userId.toString() === sciper
-      );
-    });
-  }
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/add_role` &&
+      request.method() === 'POST' &&
+      body.permission === 'vote' &&
+      body.subject === FORMID &&
+      body.userIds.toString() === [
+        SCIPER_OTHER_ADMIN,
+        SCIPER_ADMIN,
+        SCIPER_USER,
+      ].join(',')
+    );
+  });
   await page.getByTestId('addVotersButton').click();
   // menu should be visible
   const textbox = await page.getByRole('textbox', { name: 'SCIPERs' });

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -49,7 +49,7 @@ async function setUpMocks(
   }
   await mockDKGActors(page, dkgActorsStatus, initialized);
   await mockAPIDKGActors(page);
-  await mockPersonalInfo(page);
+  await mockPersonalInfo(page, SCIPER_ADMIN); // initially log in as admin to be able to access page
   await mockDKGActorsFormID(page);
   await mockServicesShuffle(page);
   await mockForms(page);
@@ -70,13 +70,6 @@ test('Assert footer is present', async ({ page }) => {
 });
 
 async function assertIsOnlyVisibleToOwner(page: Page, locator: Locator) {
-  await test.step('Assert is hidden to unauthenticated user', async () => {
-    await expect(locator).toBeHidden();
-  });
-  await test.step('Assert is hidden to authenticated non-admin user', async () => {
-    await logIn(page, SCIPER_USER);
-    await expect(locator).toBeHidden();
-  });
   await test.step('Assert is hidden to non-owner admin', async () => {
     await logIn(page, SCIPER_ADMIN);
     await expect(locator).toBeHidden();
@@ -388,17 +381,6 @@ test('Assert "Vote" button is visible to admin/non-admin voter user', async ({ p
     [1],
     // eslint-disable-next-line @typescript-eslint/no-shadow
     async function (page: Page, locator: Locator) {
-      await test.step('Assert is hidden to unauthenticated user', async () => {
-        await expect(locator).toBeHidden();
-      });
-      await test.step('Assert is hidden to authenticated non-voter user', async () => {
-        await logIn(page, SCIPER_OTHER_USER);
-        await expect(locator).toBeHidden();
-      });
-      await test.step('Assert is visible to authenticated voter user', async () => {
-        await logIn(page, SCIPER_USER);
-        await expect(locator).toBeVisible();
-      });
       await test.step('Assert is hidden to non-voter admin', async () => {
         await logIn(page, SCIPER_OTHER_ADMIN);
         await expect(locator).toBeHidden();
@@ -413,11 +395,6 @@ test('Assert "Vote" button is visible to admin/non-admin voter user', async ({ p
 
 test('Assert "Vote" button gets voting form', async ({ page }) => {
   await setUpMocks(page, 1, 6);
-  await logIn(page, SCIPER_USER);
-  page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`);
-  await page.getByRole('button', { name: i18n.t('vote') }).click();
-  // go back to form management page
-  await setUp(page, `/forms/${FORMID}`);
   await logIn(page, SCIPER_ADMIN);
   page.waitForRequest(`${process.env.DELA_PROXY_URL}/evoting/forms/${FORMID}`);
   await page.getByRole('button', { name: i18n.t('vote') }).click();

--- a/web/frontend/tests/result.spec.ts
+++ b/web/frontend/tests/result.spec.ts
@@ -114,7 +114,7 @@ test('Assert individual results are displayed correctly', async ({ page }) => {
             j + 1
           }]`
         );
-        await expect(resultRow.locator('xpath=./div[2]')).toContainText(JSON.parse(choice).en);
+        await expect(resultRow.locator('xpath=./div[2]')).toContainText(JSON.parse(choice.Choice).en);
         if (result.at(j)) {
           await expect(resultRow.getByRole('checkbox')).toBeChecked();
         } else {

--- a/web/frontend/tests/result.spec.ts
+++ b/web/frontend/tests/result.spec.ts
@@ -114,7 +114,9 @@ test('Assert individual results are displayed correctly', async ({ page }) => {
             j + 1
           }]`
         );
-        await expect(resultRow.locator('xpath=./div[2]')).toContainText(JSON.parse(choice.Choice).en);
+        await expect(resultRow.locator('xpath=./div[2]')).toContainText(
+          JSON.parse(choice.Choice).en
+        );
         if (result.at(j)) {
           await expect(resultRow.getByRole('checkbox')).toBeChecked();
         } else {


### PR DESCRIPTION
Changes that were forgotten to include:

* ballot API changed
* build information was updated
* unauthenticated users cannot access the election forms at all anymore
* the userIDs are batched in the addVoters API
