### PR TITLE
Fixed the authentication failures on the Dev route

### DIFF
--- a/web/backend/src/controllers/authentication.ts
+++ b/web/backend/src/controllers/authentication.ts
@@ -14,99 +14,110 @@ const tenantId = process.env.MS_ENTRA_TENANT_ID || '';
 const clientId = process.env.MS_ENTRA_CLIENT_ID || '';
 const redirectUri = process.env.MS_ENTRA_REDIRECT_URI || '';
 const clientSecret = process.env.MS_ENTRA_CLIENT_SECRET || '';
-if (!(tenantId && clientId && redirectUri && clientSecret)) {
+const devLoginEnabled = process.env.REACT_APP_DEV_LOGIN === 'true';
+
+if (!devLoginEnabled && !(tenantId && clientId && redirectUri && clientSecret)) {
   throw new Error('required Microsoft Entra ID environment variables are not set');
 }
 
-const issuer = new URL(`https://login.microsoftonline.com/${tenantId}/v2.0`);
 const codeChallengeMethod = 'S256';
-const client: oauth.Client = { client_id: clientId };
-const clientAuth = oauth.ClientSecretPost(clientSecret);
 
 let as: oauth.AuthorizationServer;
 let codeVerifier: string;
 let nonce: string;
 
 export async function initOAuth() {
+  if (devLoginEnabled) {
+    console.log('Microsoft Entra ID disabled because development login is enabled');
+    return;
+  }
+
+  const issuer = new URL(`https://login.microsoftonline.com/${tenantId}/v2.0`);
   as = await oauth.processDiscoveryResponse(issuer, await oauth.discoveryRequest(issuer));
   console.log('Discovered authorization server');
 }
 
-// authorization endpoint
-authenticationRouter.get('/auth-redirect', async (req, res) => {
-  try {
-    codeVerifier = oauth.generateRandomCodeVerifier();
-    const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier);
-    if (!as?.authorization_endpoint) {
-      throw new Error('Invalid authorization endpoint');
+// Register Microsoft Entra ID routes only when development login is disabled.
+if (!devLoginEnabled) {
+  const client: oauth.Client = { client_id: clientId };
+  const clientAuth = oauth.ClientSecretPost(clientSecret);
+
+  // authorization endpoint
+  authenticationRouter.get('/auth-redirect', async (req, res) => {
+    try {
+      codeVerifier = oauth.generateRandomCodeVerifier();
+      const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier);
+      if (!as?.authorization_endpoint) {
+        throw new Error('Invalid authorization endpoint');
+      }
+      const authorizationUrl = new URL(as.authorization_endpoint);
+      authorizationUrl.searchParams.set('client_id', client.client_id);
+      authorizationUrl.searchParams.set('redirect_uri', redirectUri);
+      authorizationUrl.searchParams.set('response_type', 'code');
+      authorizationUrl.searchParams.set('scope', 'openid email');
+      authorizationUrl.searchParams.set('code_challenge', codeChallenge);
+      authorizationUrl.searchParams.set('code_challenge_method', codeChallengeMethod);
+
+      // backwards compatibility
+      // https://github.com/panva/oauth4webapi/blob/222d1cc7b8e5f81ec1bbaab8ff364209e9dd7d98/examples/oidc.ts#L48
+      if (as.code_challenge_methods_supported?.includes(codeChallengeMethod) !== true) {
+        nonce = oauth.generateRandomNonce();
+        authorizationUrl.searchParams.set('nonce', nonce);
+      }
+
+      // redirect user to Microsoft Entra ID authentication
+      res.json({ url: authorizationUrl.href });
+    } catch (error) {
+      res.status(500).send('Failed to redirect to Microsoft Entra ID for authentication');
+      console.error(error);
     }
-    const authorizationUrl = new URL(as.authorization_endpoint);
-    authorizationUrl.searchParams.set('client_id', client.client_id);
-    authorizationUrl.searchParams.set('redirect_uri', redirectUri);
-    authorizationUrl.searchParams.set('response_type', 'code');
-    authorizationUrl.searchParams.set('scope', 'openid email');
-    authorizationUrl.searchParams.set('code_challenge', codeChallenge);
-    authorizationUrl.searchParams.set('code_challenge_method', codeChallengeMethod);
+  });
 
-    // backwards compatibility
-    // https://github.com/panva/oauth4webapi/blob/222d1cc7b8e5f81ec1bbaab8ff364209e9dd7d98/examples/oidc.ts#L48
-    if (as.code_challenge_methods_supported?.includes(codeChallengeMethod) !== true) {
-      nonce = oauth.generateRandomNonce();
-      authorizationUrl.searchParams.set('nonce', nonce);
+  // redirection URI
+  authenticationRouter.get(redirectUri.split('/api')[1], async (req, res) => {
+    try {
+      const params = oauth.validateAuthResponse(
+        as,
+        { client_id: clientId },
+        new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`)
+      );
+      const response = await oauth.authorizationCodeGrantRequest(
+        as,
+        { client_id: clientId },
+        clientAuth,
+        params,
+        redirectUri,
+        codeVerifier
+      );
+      const result = await oauth.processAuthorizationCodeResponse(as, client, response, {
+        expectedNonce: nonce,
+        requireIdToken: true,
+      });
+      const claims = oauth.getValidatedIdTokenClaims(result);
+      if (!(claims?.uniqueid && claims?.family_name && claims?.given_name)) {
+        throw new Error('Invalid authentication response');
+      }
+      req.session.userId = parseInt(claims.uniqueid as string, 10);
+      req.session.lastName = claims.family_name as string;
+      req.session.firstName = claims.given_name as string;
+
+      // log user in into React app
+      const sciperSessions = sciper2sess.get(req.session.userId) || new Set<string>();
+      sciperSessions.add(req.sessionID);
+      sciper2sess.set(req.session.userId, sciperSessions);
+
+      console.log(`user ${req.session.userId} successfully logged in`);
+
+      res.redirect('/logged');
+    } catch (error) {
+      res.status(500).send('Failed to log in user');
+      console.error(error);
     }
-
-    // redirect user to Microsoft Entra ID authentication
-    res.json({ url: authorizationUrl.href });
-  } catch (error) {
-    res.status(500).send('Failed to redirect to Microsoft Entra ID for authentication');
-    console.error(error);
-  }
-});
-
-// redirection URI
-authenticationRouter.get(redirectUri.split('/api')[1], async (req, res) => {
-  try {
-    const params = oauth.validateAuthResponse(
-      as,
-      { client_id: clientId },
-      new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`)
-    );
-    const response = await oauth.authorizationCodeGrantRequest(
-      as,
-      { client_id: clientId },
-      clientAuth,
-      params,
-      redirectUri,
-      codeVerifier
-    );
-    const result = await oauth.processAuthorizationCodeResponse(as, client, response, {
-      expectedNonce: nonce,
-      requireIdToken: true,
-    });
-    const claims = oauth.getValidatedIdTokenClaims(result);
-    if (!(claims?.uniqueid && claims?.family_name && claims?.given_name)) {
-      throw new Error('Invalid authentication response');
-    }
-    req.session.userId = parseInt(claims.uniqueid as string, 10);
-    req.session.lastName = claims.family_name as string;
-    req.session.firstName = claims.given_name as string;
-
-    // log user in into React app
-    const sciperSessions = sciper2sess.get(req.session.userId) || new Set<string>();
-    sciperSessions.add(req.sessionID);
-    sciper2sess.set(req.session.userId, sciperSessions);
-
-    console.log(`user ${req.session.userId} successfully logged in`);
-
-    res.redirect('/logged');
-  } catch (error) {
-    res.status(500).send('Failed to log in user');
-    console.error(error);
-  }
-});
+  });
+}
 
 authenticationRouter.get('/get_dev_login/:userId', (req, res) => {
-  if (process.env.REACT_APP_DEV_LOGIN !== 'true') {
+  if (!devLoginEnabled) {
     const err = `/get_dev_login can only be called with REACT_APP_DEV_LOGIN===true: ${process.env.REACT_APP_DEV_LOGIN}`;
     console.error(err);
     res.status(500).send(err);


### PR DESCRIPTION
Fixes local development login when Microsoft Entra credentials are unavailable.

With REACT_APP_DEV_LOGIN=true, the backend previously initialized Entra authentication during startup. This caused clean local deployments to fail with:

- required Microsoft Entra ID environment variables are not set
- TypeError: "clientSecret" must not be empty

**Changes**

When development login is enabled:

- Skip Entra credential validation and discovery.
- Skip Entra client initialization.
- Do not register Entra-specific authentication routes.
- Keep development login and shared session routes available.

**Testing**

Tested from a clean WSL/Linux environment using Docker:

- scripts/run_docker.sh setup completed with exit code 0.
- Development login cookie was created successfully.
- All four DELA proxies were added.
- /api/personal_info returned the authenticated development user.
- Backend ESLint passed.
- Backend Prettier check passed.
- TypeScript compilation passed.

Closes #215