### PR TITLE
228 Tag Docker images with version or commit hash 

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -14,8 +16,8 @@ jobs:
     env:
       # use version tag if it exists on commit else default
       # (default will always be created in addition to other tags)
-      DockerTag: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
-      push: ${{ (github.ref == 'refs/heads/main') && 'true' || 'false' }}
+      DockerTag: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+      push: ${{ (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || 'false' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Updates the Docker build workflow so automatically built images use the Git version tag when the commit is versioned, or the commit hash otherwise.

Also enables Docker builds on version tag pushes and allows those images to be published to GHCR.

Closes #228



When previously it would have said `ghcr.io/c4dt/d-voting-frontend::latest`. It now uses the commit hash for unversioned builds, or the Git version tag for tagged builds.

<img width="1084" height="486" alt="image" src="https://github.com/user-attachments/assets/7c6ad61f-bb2c-4c70-b654-39d4b20a83f6" />
